### PR TITLE
feat: protect dashbord route

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,9 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware(async (auth) => {
-  await auth.protect();
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect();
 });
 
 export const config = {


### PR DESCRIPTION
This pull request includes a change to the `middleware.ts` file to improve route protection logic.

* Added `createRouteMatcher` import to facilitate route matching.
* Modified the `clerkMiddleware` to use `createRouteMatcher` for protecting specific routes, specifically those matching `/dashboard(.*)`.